### PR TITLE
upgrade dotnet8, support custom Namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ dotnet-tool-gist is a command-line tool for using GitHub Gists as a package repo
 
 ## Introduction
 
-There are several reasons why you might choose to use a package manager based on **GitHub Gist** over another one like *NuGet*:
+There are several reasons why you might choose to use a package manager based on **GitHub Gist** over another one like _NuGet_:
 
 - **Simplicity**: GitHub Gist is a simple way to share code snippets and small applications. It requires no setup, and you can create a gist with just a few clicks. This makes it a great option if you need to share code quickly and easily.
 
@@ -31,7 +31,7 @@ There are several reasons why you might choose to use a package manager based on
 
 - **Community**: GitHub Gist is part of the GitHub ecosystem, which has a large and active community of developers. This means that there are many resources available if you need help with your code, and you can easily find examples of how others have solved similar problems.
 
-However, it's important to note that GitHub Gist is not a full-fledged package manager like *NuGet*. It's best suited for sharing small code snippets or simple applications, rather than managing complex dependencies for larger projects. Ultimately, the choice of which package manager to use will depend on your specific needs and the requirements of your project.
+However, it's important to note that GitHub Gist is not a full-fledged package manager like _NuGet_. It's best suited for sharing small code snippets or simple applications, rather than managing complex dependencies for larger projects. Ultimately, the choice of which package manager to use will depend on your specific needs and the requirements of your project.
 
 ## Installation
 
@@ -62,7 +62,7 @@ Once you have dotnet-tool-gist installed, you can use it to manage your GitHub G
 Add a gist reference to a project.
 
 ```bash
-dotnet gist [<project>] add <gist-id> [--version <version>] [--file <file>] [--out <out>]
+dotnet gist [<project>] add <gist-id> [--version <version>] [--file <file>] [--out <out>] [--namespace <namespace>]
 ```
 
 - `<project>`: The project file to add the reference. If not specified, the current directory must be a project.
@@ -70,7 +70,8 @@ dotnet gist [<project>] add <gist-id> [--version <version>] [--file <file>] [--o
 - `<version>`: The gist version. If not specified, the latest version will be used.
 - `<file>`: The file glob pattern to add. If not specified, all files will be added.
 - `<out>`: The output directory. If not specified, the files will be added to the project directory: `gist/<gist-id>/<gist-version>`.
-
+- `<namespace>`: The custom Namespace.
+  
 Some examples:
 
 ```
@@ -78,6 +79,7 @@ dotnet gist add <gist-id>
 dotnet gist MyProject/MyProject.csproj add <gist-id>
 dotnet gist MyProject/MyProject.csproj add <gist-id> --version <version>
 dotnet gist MyProject/MyProject.csproj add <gist-id> --version <version> --file *.cs
+dotnet gist MyProject/MyProject.csproj add <gist-id> --namespace MyProject
 dotnet gist add <gist-id> --version <version> --file *.cs --out ReferencedCode/
 ```
 
@@ -138,6 +140,7 @@ Each gist reference is added to the project as a `GistReference` item under `Pro
 - `Version`: The gist version.
 - `FilePattern`: The file glob pattern used to add the files.
 - `OutputPath`: The output directory.
+- `Namespace`: The custom Namespace.
 
 There is an internal cache of the gist files that is used to avoid downloading the same gist multiple times. The cache is stored in the `.gist` folder under the `obj` project folder.
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -34,7 +34,7 @@ Then, you need to add the gist reference to the project. You can do it by runnin
 
 ```bash
 cd DemoApi
-dotnet gist add fd0f87915264038fa463966428da2986 --out ./
+dotnet gist add fd0f87915264038fa463966428da2986 --out ./ --namespace DemoApi
 ```
 
 It will add a file called `RecordEndpoints.cs` to root directory of the project.

--- a/src/Core/Commands/AddCommand.cs
+++ b/src/Core/Commands/AddCommand.cs
@@ -6,18 +6,21 @@ public class AddCommand : CommandBase
     private readonly Option<string> _versionOption;
     private readonly Option<string> _fileOption;
     private readonly Option<string> _outOption;
+    private readonly Option<string> _nsOption;
 
     public AddCommand() : base("add", "Add gist reference to the project")
     {
         _gistIdArgument = new Argument<string>("gist_id", "The gist id");
-        _versionOption  = new Option<string>(new [] { "-v", "--version" }, "The gist version");
-        _fileOption  = new Option<string>(new [] { "-f", "--file" }, "The file filter glob pattern");
-        _outOption  = new Option<string>(new [] { "-o", "--out" }, "The output path");
+        _versionOption = new Option<string>(["-v", "--version"], "The gist version");
+        _fileOption = new Option<string>(["-f", "--file"], "The file filter glob pattern");
+        _outOption = new Option<string>(["-o", "--out"], "The output path");
+        _nsOption = new Option<string>(["-ns", "--namespace"], "The Namespace");
 
         AddArgument(_gistIdArgument);
         AddOption(_versionOption);
         AddOption(_fileOption);
         AddOption(_outOption);
+        AddOption(_nsOption);
     }
 
     protected override async Task OnHandleAsync(CommandContext ctx)
@@ -26,6 +29,7 @@ public class AddCommand : CommandBase
         var _gistVersion = ctx.ParseResult.GetValueForOption<string>(_versionOption);
         var _filePattern = ctx.ParseResult.GetValueForOption<string>(_fileOption);
         var _outputPath = ctx.ParseResult.GetValueForOption<string>(_outOption);
+        var _customNamespace = ctx.ParseResult.GetValueForOption<string>(_nsOption);
 
 
         var gist = await ctx.GetGistAsync(_gistId, _gistVersion);
@@ -50,7 +54,8 @@ public class AddCommand : CommandBase
             Id = _gistId,
             Version = _gistVersion,
             FilePattern = _filePattern,
-            OutputPath = _outputPath
+            OutputPath = _outputPath,
+            Namespace = _customNamespace
         };
 
         ctx.Console.AddingGistReference(gistReference);

--- a/src/Infrastructure/MsBuild/GistReferenceItem.cs
+++ b/src/Infrastructure/MsBuild/GistReferenceItem.cs
@@ -9,4 +9,6 @@ public class GistReferenceItem
     public string? FilePattern { get; set; }
 
     public string? OutputPath { get; set; }
+
+    public string? Namespace { get; set; }
 }

--- a/src/Infrastructure/MsBuild/Project.cs
+++ b/src/Infrastructure/MsBuild/Project.cs
@@ -40,6 +40,7 @@ public class Project
                         item.Version = element.Attribute(nameof(GistReferenceItem.Version))?.Value;
                         item.FilePattern = element.Attribute(nameof(GistReferenceItem.FilePattern))?.Value;
                         item.OutputPath = element.Attribute(nameof(GistReferenceItem.OutputPath))?.Value;
+                        item.Namespace = element.Attribute(nameof(GistReferenceItem.Namespace))?.Value;
                         items.Add(item);
                     }
                 }
@@ -58,7 +59,7 @@ public class Project
             var itemGroups = _document.Value.Root?.Elements(ns + GistReferenceContainerName);
             if (itemGroups is not null)
             {
-                foreach(var i in itemGroups)
+                foreach (var i in itemGroups)
                 {
                     var elements = i.Elements(ns + GistReferenceName);
                     if (elements.Any())
@@ -94,6 +95,11 @@ public class Project
             if (item.OutputPath is not null)
             {
                 element.Add(new XAttribute(nameof(GistReferenceItem.OutputPath), item.OutputPath));
+            }
+
+            if (item.Namespace is not null)
+            {
+                element.Add(new XAttribute(nameof(GistReferenceItem.Namespace), item.Namespace));
             }
 
             itemGroup.Add(element);

--- a/src/Infrastructure/MsBuild/ProjectFinder.cs
+++ b/src/Infrastructure/MsBuild/ProjectFinder.cs
@@ -1,21 +1,21 @@
 namespace DotnetGist.Infrastructure.MsBuild;
 
-public class ProjectFinder
+public static class ProjectFinder
 {
     public static string[] Run(string? directory = null)
     {
         directory ??= Directory.GetCurrentDirectory();
 
-        var patterns = "*.csproj;*.vbproj;*.fsproj";
-        foreach(var pattern in patterns.Split(';'))
+        const string patterns = "*.csproj;*.vbproj;*.fsproj";
+        foreach (var pattern in patterns.Split(';'))
         {
             var files = Directory.GetFiles(directory, pattern);
-            if(files.Length > 0)
+            if (files.Length > 0)
             {
                 return files;
             }
         }
 
-        return new string[0];
+        return [];
     }
 }

--- a/src/dotnet-gist.csproj
+++ b/src/dotnet-gist.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>DotnetGist</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -17,8 +17,8 @@
     <ToolCommandName>dotnet-gist</ToolCommandName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Hi Fernando,

This PR adds a new option that allows users to replace namespaces in imported Gist files. And upgrade to dotnet 8 (LTS) btw.

I’ve tested it against multiple edge cases (file-scoped namespaces, VB casing, F# modules).

Let me know if you'd like any changes or improvements. I’d be happy to iterate!

Thanks for creating such a cool tool.